### PR TITLE
Added rpm to dependencies installation for Trivy.

### DIFF
--- a/script/custom/provision-trivy.sh
+++ b/script/custom/provision-trivy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 echo "Provisioning trivy"
-apt-get install -y wget apt-transport-https gnupg lsb-release
+apt-get install -y wget apt-transport-https gnupg lsb-release rpm
 wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
 echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | sudo tee -a /etc/apt/sources.list.d/trivy.list
 apt-get -y update


### PR DESCRIPTION
Trivy depends on rpm when scanning RHEL/CentOS.